### PR TITLE
Fixing instances where the query parameters were not correctly formatted which meant the http requests failed

### DIFF
--- a/tflwrapper/line.py
+++ b/tflwrapper/line.py
@@ -61,11 +61,11 @@ class line(tflAPI):
         """
         if startDate == None or endDate == None:
             return super(line, self).sendRequestUnified(
-                f"/Line/{self.arrayToCSV(lines)}/Status", { detail }
+                f"/Line/{self.arrayToCSV(lines)}/Status", {'detail': detail }
             )
         else:
             return super(line, self).sendRequestUnified(
-                f"/Line/{self.arrayToCSV(lines)}/Status/{self.getRFC3339(startDate)}/to/{self.getRFC3339(endDate)}", { detail }
+                f"/Line/{self.arrayToCSV(lines)}/Status/{self.getRFC3339(startDate)}/to/{self.getRFC3339(endDate)}", {'detail': detail }
             )
 
     def getStatusByModes(self, modes, detail = False, severityLevel = ""):
@@ -78,7 +78,7 @@ class line(tflAPI):
             severityLevel: A list of severity codes to filter on. Supported values: Minor, Major, Severe
         """
         return super(line, self).sendRequestUnified(
-            f"/Line/Mode/{self.arrayToCSV(modes)}/Status", { detail, severityLevel }
+            f"/Line/Mode/{self.arrayToCSV(modes)}/Status", {'detail': detail, 'severityLevel': severityLevel }
         )
 
     def getTimetableFromTo(self, _line, _from, _to):

--- a/tflwrapper/stopPoint.py
+++ b/tflwrapper/stopPoint.py
@@ -34,7 +34,7 @@ class stopPoint(tflAPI):
         """
 
         return super(stopPoint, self).sendRequestUnified(
-            f"/StopPoint/{','.join(ids)}", {includeCrowdingData}
+            f"/StopPoint/{','.join(ids)}", {'includeCrowdingData': includeCrowdingData}
         )
 
     def getAllByStopType(self, array):
@@ -99,7 +99,7 @@ class stopPoint(tflAPI):
     #     """
 
     #     return super(stopPoint, self).sendRequestUnified(
-    #         f"StopPoint/${naptanID}/ArrivalsDepartures", {lineIds}
+    #         f"StopPoint/${naptanID}/ArrivalsDepartures", {'lineIds': lineIds}
     #     )
 
     def getDisruptionsByID(
@@ -121,7 +121,7 @@ class stopPoint(tflAPI):
 
         return super(stopPoint, self).sendRequestUnified(
             f"/StopPoint/{super(stopPoint, self).arrayToCSV(ids)}/Disruption",
-            {getFamily, includeRouteBlockedStops, flattenResponse},
+            {'getFamily': getFamily, 'includeRouteBlockedStops': includeRouteBlockedStops, 'flattenResponse': flattenResponse},
         )
 
     def getDisruptionsByMode(self, modes, includeRouteBlockedStops: bool):
@@ -134,7 +134,7 @@ class stopPoint(tflAPI):
         """
         return super(stopPoint, self).sendRequestUnified(
             f"/StopPoint/Mode/{super(stopPoint, self).arrayToCSV(modes)}/Disruption",
-            {includeRouteBlockedStops},
+            {'includeRouteBlockedStops': includeRouteBlockedStops},
         )
 
     def getReachableStationsByID(self, naptanID: str, lineID: str, serviceTypes=None):
@@ -217,7 +217,7 @@ class stopPoint(tflAPI):
         """
 
         return super(stopPoint, self).sendRequestUnified(
-            f"/StopPoint/Sms/{smsID}", {output}
+            f"/StopPoint/Sms/{smsID}", {'output': output}
         )
 
     def getTaxiRanksByID(self, naptanID: str):


### PR DESCRIPTION
In trying to use `stoppoint.getByIDs(['940GZZLUAS'], False)` I got an error because the query parameters are not correctly formatted and so you get the error showed below.

This PR fixes this error. I have tested it with `stoppoint.getByIDs`. I have made the same change elsewhere but have not tested those occurrences. But they wouldn't have been working anyway so…

`Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/parse.py", line 936, in urlencode
    if len(query) and not isinstance(query[0], tuple):
                                     ~~~~~^^^
TypeError: 'set' object is not subscriptable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/paulwheeler/Development/tfl-api-wrapper-py/tflwrapper/stopPoint.py", line 36, in getByIDs
    return super(stopPoint, self).sendRequestUnified(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/paulwheeler/Development/tfl-api-wrapper-py/tflwrapper/tfl.py", line 30, in sendRequestUnified
    fullURL += f"&{urllib.parse.urlencode(params)}"
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/parse.py", line 943, in urlencode
    raise TypeError("not a valid non-string sequence "
TypeError: not a valid non-string sequence or mapping object
`