### PR TITLE
Fix getAllStopPoints 'line' arg/class conflict

### DIFF
--- a/tflwrapper/line.py
+++ b/tflwrapper/line.py
@@ -28,7 +28,7 @@ class line(tflAPI):
             "/Line/Meta/ServiceTypes"
         )
 
-    def getAllStopPoints(self, line):
+    def getAllStopPoints(self, _line):
         """
         Gets a list of the stations that serve the given line id
 
@@ -36,7 +36,7 @@ class line(tflAPI):
             line: The line id e.g. victoria, circle, N133        
         """
         return super(line, self).sendRequestUnified(
-            F"/Line/{line}/StopPoints"
+            F"/Line/{_line}/StopPoints"
         )
     
 


### PR DESCRIPTION
Trying to run `line.getAllStopPoints` results in an error:

> ```
> File "<project>\env\Lib\site-packages\tflwrapper\line.py", line 38, in getAllStopPoints
>    return super(line, self).sendRequestUnified(
>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> TypeError: super() argument 1 must be a type, not str
> ```

because the `line` parameter (`def getAllStopPoints(self, line)`) and the `line` class (`super(line, self)`) have the same name.

This PR fixes that by renaming the parameter to `line_`, as had already been done in other similar methods on the `line` class.